### PR TITLE
Show elevation for more cities

### DIFF
--- a/src/WeatherLocation.tsx
+++ b/src/WeatherLocation.tsx
@@ -1,7 +1,7 @@
 import countries from "i18n-iso-countries";
 import enLocale from "i18n-iso-countries/langs/en.json";
 
-import { fetchTimeZone } from "./api/OpenMeteo";
+import { fetchElevation, fetchTimeZone } from "./api/OpenMeteo";
 import { fetchReverseCityLocations } from "./api/OpenWeather";
 
 countries.registerLocale(enLocale);
@@ -41,7 +41,7 @@ export function formatLongitude(longitude: number): string {
 }
 
 export function formatElevation(elevation: number): string {
-  return `${elevation.toFixed(1)} ft`;
+  return `${elevation.toFixed(1)} m`;
 }
 
 export function getFullCountryName(
@@ -66,14 +66,16 @@ export async function reverseWeatherLocation(
   }
 
   const firstResult = data[0];
+  const elevation = await fetchElevation(latitude, longitude);
   const timeZone = await fetchTimeZone(latitude, longitude);
-  console.log(timeZone);
+
   return {
     city: firstResult.name,
     state: firstResult.state,
     country: getFullCountryName(firstResult.country, firstResult.country),
     latitude, // use original coordinates
     longitude,
+    elevation,
     timeZone,
   };
 }

--- a/src/api/OpenMeteo.tsx
+++ b/src/api/OpenMeteo.tsx
@@ -11,6 +11,7 @@ import { WmoCode } from "../components/WmoCode";
 const API_BASE_URL = "https://api.open-meteo.com/v1/forecast";
 const API_ARCHIVE_URL = "https://archive-api.open-meteo.com/v1/archive";
 const API_GEOCODING_URL = "https://geocoding-api.open-meteo.com/v1/search";
+const API_ELEVATION_URL = "https://api.open-meteo.com/v1/elevation";
 
 export interface DailyData {
   time: string[];
@@ -89,6 +90,24 @@ export async function fetchTimeZone(
   if (response.ok) {
     const data = (await response.json()) as { timezone: string };
     return data.timezone;
+  } else {
+    throw new Error("Failed to fetch data");
+  }
+}
+
+export async function fetchElevation(
+  latitude: number,
+  longitude: number,
+): Promise<number> {
+  // Construct the API URL based on the provided latitude and longitude
+  const url = `${API_ELEVATION_URL}?latitude=${latitude}&longitude=${longitude}`;
+
+  // Make an asynchronous HTTP GET request to the API
+  const response = await fetch(url);
+
+  if (response.ok) {
+    const data = (await response.json()) as { elevation: number[] };
+    return data.elevation[0];
   } else {
     throw new Error("Failed to fetch data");
   }

--- a/src/components/CurrentLocation/index.tsx
+++ b/src/components/CurrentLocation/index.tsx
@@ -64,7 +64,7 @@ function CurrentLocation({
             </Tooltip>
 
             {weatherLocation.elevation !== undefined && (
-              <Tooltip title="Elevation">
+              <Tooltip title="Elevation (meters)">
                 <Chip label={formatElevation(weatherLocation.elevation)} />
               </Tooltip>
             )}


### PR DESCRIPTION
This PR uses the Open-Meteo elevation API (https://open-meteo.com/en/docs/elevation-api) to get the elevation of cities that weren't located through other Open-Meteo APIs. It is useful for when the location is from the device position or from clicking on the interactive map.

I also fixed the elevation unit. It was incorrectly displayed as feet when it should be meters according to data from other websites.