### PR TITLE
Consistent location component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,17 +23,15 @@ function App() {
     <>
       <AppBar position="sticky" sx={{ bgcolor: "#0f172a" }}>
         <Toolbar>
-          <Box flexGrow={1}>
-            <Button color="inherit" component={Link} to="/">
-              Home
-            </Button>
-            <Button color="inherit" component={Link} to="/maps">
-              Maps
-            </Button>
-            <Button color="inherit" component={Link} to="/history">
-              History
-            </Button>
-          </Box>
+          <Button color="inherit" component={Link} to="/">
+            Home
+          </Button>
+          <Button color="inherit" component={Link} to="/maps">
+            Maps
+          </Button>
+          <Button color="inherit" component={Link} to="/history">
+            History
+          </Button>
           <LocationJumpButton
             searchRef={searchRef}
             locationExpanded={locationExpanded}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -59,6 +59,7 @@ function App() {
             path="/maps"
             element={
               <MapsPage
+                searchRef={searchRef}
                 units={units}
                 setUnits={setUnits}
                 weatherLocation={weatherLocation}
@@ -70,6 +71,7 @@ function App() {
             path="/history"
             element={
               <HistoryPage
+                searchRef={searchRef}
                 units={units}
                 setUnits={setUnits}
                 weatherLocation={weatherLocation}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState } from "react";
 import { Link, Route, Routes } from "react-router-dom";
 
-import { AppBar, Button, Toolbar } from "@mui/material";
+import { AppBar, Button, Container, Toolbar } from "@mui/material";
 
 import { WeatherLocation, defaultLocation } from "./WeatherLocation";
 import HistoryPage from "./components/HistoryPage";
@@ -21,25 +21,27 @@ function App() {
   return (
     <>
       <AppBar position="sticky" sx={{ bgcolor: "#0f172a" }}>
-        <Toolbar>
-          <Button color="inherit" component={Link} to="/">
-            Home
-          </Button>
-          <Button color="inherit" component={Link} to="/maps">
-            Maps
-          </Button>
-          <Button color="inherit" component={Link} to="/history">
-            History
-          </Button>
-          <LocationJumpButton
-            searchRef={searchRef}
-            locationExpanded={locationExpanded}
-            setLocationExpanded={setLocationExpanded}
-            weatherLocation={weatherLocation}
-            setWeatherLocation={setWeatherLocation}
-          />
-          <UnitButton units={units} setUnits={setUnits} />
-        </Toolbar>
+        <Container sx={{ padding: 0 }}>
+          <Toolbar>
+            <Button color="inherit" component={Link} to="/">
+              Home
+            </Button>
+            <Button color="inherit" component={Link} to="/maps">
+              Maps
+            </Button>
+            <Button color="inherit" component={Link} to="/history">
+              History
+            </Button>
+            <LocationJumpButton
+              searchRef={searchRef}
+              locationExpanded={locationExpanded}
+              setLocationExpanded={setLocationExpanded}
+              weatherLocation={weatherLocation}
+              setWeatherLocation={setWeatherLocation}
+            />
+            <UnitButton units={units} setUnits={setUnits} />
+          </Toolbar>
+        </Container>
       </AppBar>
       <main>
         <Routes>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ function App() {
   const [weatherLocation, setWeatherLocation] =
     useState<WeatherLocation>(defaultLocation);
 
+  const [locationExpanded, setLocationExpanded] = useState<boolean>(false);
   const searchRef = useRef<HTMLInputElement | null>(null);
 
   return (
@@ -35,6 +36,8 @@ function App() {
           </Box>
           <LocationJumpButton
             searchRef={searchRef}
+            locationExpanded={locationExpanded}
+            setLocationExpanded={setLocationExpanded}
             weatherLocation={weatherLocation}
             setWeatherLocation={setWeatherLocation}
           />
@@ -48,6 +51,8 @@ function App() {
             element={
               <HomePage
                 searchRef={searchRef}
+                locationExpanded={locationExpanded}
+                setLocationExpanded={setLocationExpanded}
                 units={units}
                 setUnits={setUnits}
                 weatherLocation={weatherLocation}
@@ -60,6 +65,8 @@ function App() {
             element={
               <MapsPage
                 searchRef={searchRef}
+                locationExpanded={locationExpanded}
+                setLocationExpanded={setLocationExpanded}
                 units={units}
                 setUnits={setUnits}
                 weatherLocation={weatherLocation}
@@ -72,6 +79,8 @@ function App() {
             element={
               <HistoryPage
                 searchRef={searchRef}
+                locationExpanded={locationExpanded}
+                setLocationExpanded={setLocationExpanded}
                 units={units}
                 setUnits={setUnits}
                 weatherLocation={weatherLocation}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,6 @@ import { useRef, useState } from "react";
 import { Link, Route, Routes } from "react-router-dom";
 
 import { AppBar, Button, Toolbar } from "@mui/material";
-import { Box } from "@mui/system";
 
 import { WeatherLocation, defaultLocation } from "./WeatherLocation";
 import HistoryPage from "./components/HistoryPage";

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { Link, Route, Routes } from "react-router-dom";
 
 import { AppBar, Button, Toolbar } from "@mui/material";
@@ -7,6 +7,7 @@ import { Box } from "@mui/system";
 import { WeatherLocation, defaultLocation } from "./WeatherLocation";
 import HistoryPage from "./components/HistoryPage";
 import HomePage from "./components/HomePage";
+import { LocationJumpButton } from "./components/LocationJumpButton";
 import MapsPage from "./components/MapsPage/MapsPage";
 import { UnitButton, Units } from "./components/UnitButton";
 
@@ -14,6 +15,8 @@ function App() {
   const [units, setUnits] = useState<Units>({ temperature: "F" });
   const [weatherLocation, setWeatherLocation] =
     useState<WeatherLocation>(defaultLocation);
+
+  const searchRef = useRef<HTMLInputElement | null>(null);
 
   return (
     <>
@@ -30,6 +33,11 @@ function App() {
               History
             </Button>
           </Box>
+          <LocationJumpButton
+            searchRef={searchRef}
+            weatherLocation={weatherLocation}
+            setWeatherLocation={setWeatherLocation}
+          />
           <UnitButton units={units} setUnits={setUnits} />
         </Toolbar>
       </AppBar>
@@ -39,6 +47,7 @@ function App() {
             index
             element={
               <HomePage
+                searchRef={searchRef}
                 units={units}
                 setUnits={setUnits}
                 weatherLocation={weatherLocation}

--- a/src/WeatherLocation.tsx
+++ b/src/WeatherLocation.tsx
@@ -44,6 +44,29 @@ export function formatElevation(elevation: number): string {
   return `${elevation.toFixed(1)} m`;
 }
 
+export function getShortLocationTitle({
+  city,
+  state,
+}: WeatherLocation): string {
+  if (city) {
+    return city;
+  } else if (state) {
+    return state;
+  }
+  return "Unknown";
+}
+
+export function getLocationTitle({ city, state }: WeatherLocation): string {
+  if (city && state) {
+    return `${city}, ${state}`;
+  } else if (city) {
+    return city;
+  } else if (state) {
+    return state;
+  }
+  return "Unknown Location";
+}
+
 export function getFullCountryName(
   code: string | undefined,
   fallback?: string,

--- a/src/components/CurrentLocation/SearchInput.tsx
+++ b/src/components/CurrentLocation/SearchInput.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { MutableRefObject, useState } from "react";
 
 import { Autocomplete, debounce } from "@mui/material";
 import TextField from "@mui/material/TextField";
@@ -8,7 +8,6 @@ import {
   getFullCountryName,
 } from "../../WeatherLocation";
 import { CityLocation, fetchCityLocations } from "../../api/OpenMeteo";
-import { SearchRefProps } from "../LocationJumpButton";
 
 function normalizeCities(cities: CityLocation[]): void {
   // Rewrite country field for consistency with weather locations acquired
@@ -29,6 +28,10 @@ function normalizeCities(cities: CityLocation[]): void {
     }
     return difference;
   });
+}
+
+export interface SearchRefProps {
+  searchRef: MutableRefObject<HTMLInputElement | null>;
 }
 
 const SearchInput = ({

--- a/src/components/CurrentLocation/SearchInput.tsx
+++ b/src/components/CurrentLocation/SearchInput.tsx
@@ -8,6 +8,7 @@ import {
   getFullCountryName,
 } from "../../WeatherLocation";
 import { CityLocation, fetchCityLocations } from "../../api/OpenMeteo";
+import { SearchRefProps } from "../LocationJumpButton";
 
 function normalizeCities(cities: CityLocation[]): void {
   // Rewrite country field for consistency with weather locations acquired
@@ -30,7 +31,10 @@ function normalizeCities(cities: CityLocation[]): void {
   });
 }
 
-const SearchInput = ({ setWeatherLocation }: WeatherLocationProps) => {
+const SearchInput = ({
+  searchRef,
+  setWeatherLocation,
+}: SearchRefProps & WeatherLocationProps) => {
   const [options, setOptions] = useState<CityLocation[]>([]);
 
   const fetchData = React.useMemo(
@@ -77,6 +81,7 @@ const SearchInput = ({ setWeatherLocation }: WeatherLocationProps) => {
       renderInput={(props) => (
         <TextField
           {...props}
+          inputRef={searchRef}
           label="Search"
           placeholder="City, Country"
           fullWidth

--- a/src/components/CurrentLocation/index.tsx
+++ b/src/components/CurrentLocation/index.tsx
@@ -46,7 +46,7 @@ function CurrentLocation({
   );
 
   return (
-    <Card>
+    <Card sx={{ height: "100%" }}>
       <CardHeader
         title={getLocationTitle(weatherLocation)}
         subheader={weatherLocation.country}

--- a/src/components/CurrentLocation/index.tsx
+++ b/src/components/CurrentLocation/index.tsx
@@ -12,31 +12,22 @@ import {
 } from "@mui/material";
 
 import {
-  WeatherLocation,
   WeatherLocationProps,
   formatElevation,
   formatLatitude,
   formatLongitude,
+  getLocationTitle,
 } from "../../WeatherLocation";
+import { SearchRefProps } from "../LocationJumpButton";
 import LocationButton from "./LocationButton";
 import { LocationState } from "./LocationState";
 import SearchInput from "./SearchInput";
 
-function getLocationTitle({ city, state }: WeatherLocation): string {
-  if (city && state) {
-    return `${city}, ${state}`;
-  } else if (city) {
-    return city;
-  } else if (state) {
-    return state;
-  }
-  return "Unknown Location";
-}
-
 function CurrentLocation({
+  searchRef,
   weatherLocation,
   setWeatherLocation,
-}: WeatherLocationProps) {
+}: SearchRefProps & WeatherLocationProps) {
   const [locationState, setLocationState] = useState<LocationState>(
     LocationState.Ready,
   );
@@ -50,6 +41,7 @@ function CurrentLocation({
       <CardContent>
         <Stack gap={2}>
           <SearchInput
+            searchRef={searchRef}
             weatherLocation={weatherLocation}
             setWeatherLocation={setWeatherLocation}
           />

--- a/src/components/CurrentLocation/index.tsx
+++ b/src/components/CurrentLocation/index.tsx
@@ -1,11 +1,14 @@
 import { useState } from "react";
 
+import { ExpandLess, ExpandMore } from "@mui/icons-material";
 import {
   Card,
   CardActions,
   CardContent,
   CardHeader,
   Chip,
+  Collapse,
+  IconButton,
   LinearProgress,
   Stack,
   Tooltip,
@@ -23,11 +26,21 @@ import LocationButton from "./LocationButton";
 import { LocationState } from "./LocationState";
 import SearchInput from "./SearchInput";
 
+export interface CurrentLocationProps
+  extends SearchRefProps,
+    WeatherLocationProps {
+  collapsible?: boolean;
+  startOpened?: boolean;
+}
+
 function CurrentLocation({
+  collapsible = false,
+  startOpened = true,
   searchRef,
   weatherLocation,
   setWeatherLocation,
-}: SearchRefProps & WeatherLocationProps) {
+}: CurrentLocationProps) {
+  const [opened, setOpened] = useState<boolean>(startOpened);
   const [locationState, setLocationState] = useState<LocationState>(
     LocationState.Ready,
   );
@@ -37,40 +50,53 @@ function CurrentLocation({
       <CardHeader
         title={getLocationTitle(weatherLocation)}
         subheader={weatherLocation.country}
+        action={
+          collapsible ? (
+            <IconButton
+              onClick={() => {
+                setOpened(!opened);
+              }}
+            >
+              {opened ? <ExpandLess /> : <ExpandMore />}
+            </IconButton>
+          ) : undefined
+        }
       />
-      <CardContent>
-        <Stack gap={2}>
-          <SearchInput
-            searchRef={searchRef}
+      <Collapse in={opened} timeout="auto">
+        <CardContent>
+          <Stack gap={2}>
+            <SearchInput
+              searchRef={searchRef}
+              weatherLocation={weatherLocation}
+              setWeatherLocation={setWeatherLocation}
+            />
+
+            <Stack direction="row" gap={1}>
+              <Tooltip title="Latitude">
+                <Chip label={formatLatitude(weatherLocation.latitude)} />
+              </Tooltip>
+
+              <Tooltip title="Longitude">
+                <Chip label={formatLongitude(weatherLocation.longitude)} />
+              </Tooltip>
+
+              {weatherLocation.elevation !== undefined && (
+                <Tooltip title="Elevation (meters)">
+                  <Chip label={formatElevation(weatherLocation.elevation)} />
+                </Tooltip>
+              )}
+            </Stack>
+          </Stack>
+        </CardContent>
+        <CardActions>
+          <LocationButton
             weatherLocation={weatherLocation}
             setWeatherLocation={setWeatherLocation}
+            locationState={locationState}
+            setLocationState={setLocationState}
           />
-
-          <Stack direction="row" gap={1}>
-            <Tooltip title="Latitude">
-              <Chip label={formatLatitude(weatherLocation.latitude)} />
-            </Tooltip>
-
-            <Tooltip title="Longitude">
-              <Chip label={formatLongitude(weatherLocation.longitude)} />
-            </Tooltip>
-
-            {weatherLocation.elevation !== undefined && (
-              <Tooltip title="Elevation (meters)">
-                <Chip label={formatElevation(weatherLocation.elevation)} />
-              </Tooltip>
-            )}
-          </Stack>
-        </Stack>
-      </CardContent>
-      <CardActions>
-        <LocationButton
-          weatherLocation={weatherLocation}
-          setWeatherLocation={setWeatherLocation}
-          locationState={locationState}
-          setLocationState={setLocationState}
-        />
-      </CardActions>
+        </CardActions>
+      </Collapse>
       {locationState === LocationState.Loading && <LinearProgress />}
     </Card>
   );

--- a/src/components/CurrentLocation/index.tsx
+++ b/src/components/CurrentLocation/index.tsx
@@ -21,26 +21,29 @@ import {
   formatLongitude,
   getLocationTitle,
 } from "../../WeatherLocation";
-import { SearchRefProps } from "../LocationJumpButton";
 import LocationButton from "./LocationButton";
 import { LocationState } from "./LocationState";
-import SearchInput from "./SearchInput";
+import SearchInput, { SearchRefProps } from "./SearchInput";
+
+export interface LocationFocusProps extends SearchRefProps {
+  locationExpanded: boolean;
+  setLocationExpanded: (expanded: boolean) => void;
+}
 
 export interface CurrentLocationProps
-  extends SearchRefProps,
+  extends LocationFocusProps,
     WeatherLocationProps {
   collapsible?: boolean;
-  startOpened?: boolean;
 }
 
 function CurrentLocation({
   collapsible = false,
-  startOpened = true,
+  locationExpanded,
+  setLocationExpanded,
   searchRef,
   weatherLocation,
   setWeatherLocation,
 }: CurrentLocationProps) {
-  const [opened, setOpened] = useState<boolean>(startOpened);
   const [locationState, setLocationState] = useState<LocationState>(
     LocationState.Ready,
   );
@@ -54,15 +57,16 @@ function CurrentLocation({
           collapsible ? (
             <IconButton
               onClick={() => {
-                setOpened(!opened);
+                setLocationExpanded(!locationExpanded);
               }}
             >
-              {opened ? <ExpandLess /> : <ExpandMore />}
+              {locationExpanded ? <ExpandLess /> : <ExpandMore />}
             </IconButton>
           ) : undefined
         }
       />
-      <Collapse in={opened} timeout="auto">
+
+      <Collapse in={!collapsible || locationExpanded} timeout="auto">
         <CardContent>
           <Stack gap={2}>
             <SearchInput

--- a/src/components/HistoryPage/index.tsx
+++ b/src/components/HistoryPage/index.tsx
@@ -8,8 +8,7 @@ import {
   fetchHistoricalWeatherData,
   fetchSunsetData,
 } from "../../api/OpenMeteo";
-import CurrentLocation from "../CurrentLocation";
-import { SearchRefProps } from "../LocationJumpButton";
+import CurrentLocation, { LocationFocusProps } from "../CurrentLocation";
 import { UnitProps } from "../UnitButton";
 import { BarChartContainer } from "./BarChart";
 import { FormattedData, formatChartData } from "./CalcHistory";
@@ -26,10 +25,12 @@ const DAYS = 7;
 
 const HistoryPage = ({
   searchRef,
+  locationExpanded,
+  setLocationExpanded,
   units,
   weatherLocation,
   setWeatherLocation,
-}: SearchRefProps & UnitProps & WeatherLocationProps) => {
+}: LocationFocusProps & UnitProps & WeatherLocationProps) => {
   const [chartData, setChartData] = useState<FormattedData>({
     monthly: {
       labels: [],
@@ -95,7 +96,8 @@ const HistoryPage = ({
           <Grid item xs={12} sm={6} md={4}>
             <CurrentLocation
               collapsible
-              startOpened={false}
+              locationExpanded={locationExpanded}
+              setLocationExpanded={setLocationExpanded}
               searchRef={searchRef}
               weatherLocation={weatherLocation}
               setWeatherLocation={setWeatherLocation}

--- a/src/components/HistoryPage/index.tsx
+++ b/src/components/HistoryPage/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-import { Container, Stack } from "@mui/material";
+import { Container, Grid, Stack, Typography } from "@mui/material";
 
 import { WeatherLocationProps } from "../../WeatherLocation";
 import {
@@ -8,6 +8,8 @@ import {
   fetchHistoricalWeatherData,
   fetchSunsetData,
 } from "../../api/OpenMeteo";
+import CurrentLocation from "../CurrentLocation";
+import { SearchRefProps } from "../LocationJumpButton";
 import { UnitProps } from "../UnitButton";
 import { BarChartContainer } from "./BarChart";
 import { FormattedData, formatChartData } from "./CalcHistory";
@@ -23,9 +25,11 @@ function everyNth<T>(array: T[], n: number): T[] {
 const DAYS = 7;
 
 const HistoryPage = ({
+  searchRef,
   units,
   weatherLocation,
-}: UnitProps & WeatherLocationProps) => {
+  setWeatherLocation,
+}: SearchRefProps & UnitProps & WeatherLocationProps) => {
   const [chartData, setChartData] = useState<FormattedData>({
     monthly: {
       labels: [],
@@ -77,6 +81,28 @@ const HistoryPage = ({
   return (
     <Container sx={{ padding: 0 }}>
       <Stack gap={2} padding={{ xs: 1, md: 2 }}>
+        <Grid container spacing={2} justifyItems="center">
+          <Grid item xs={12} sm={6} md={8} alignSelf="center">
+            <Typography
+              height="100%"
+              variant="h2"
+              component="h1"
+              textAlign="center"
+            >
+              Historical Data
+            </Typography>
+          </Grid>
+          <Grid item xs={12} sm={6} md={4}>
+            <CurrentLocation
+              collapsible
+              startOpened={false}
+              searchRef={searchRef}
+              weatherLocation={weatherLocation}
+              setWeatherLocation={setWeatherLocation}
+            />
+          </Grid>
+        </Grid>
+
         <BarChartContainer
           title="Highest/Lowest Temperature"
           labels={chartData.monthly.labels}

--- a/src/components/HistoryPage/index.tsx
+++ b/src/components/HistoryPage/index.tsx
@@ -75,8 +75,8 @@ const HistoryPage = ({
   }, [weatherLocation.latitude, weatherLocation.longitude]);
 
   return (
-    <Container>
-      <Stack gap={3} padding={2}>
+    <Container sx={{ padding: 0 }}>
+      <Stack gap={2} padding={{ xs: 1, md: 2 }}>
         <BarChartContainer
           title="Highest/Lowest Temperature"
           labels={chartData.monthly.labels}

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -9,16 +9,18 @@ import CurrentWeather from "./CurrentWeather";
 import DailyForecast from "./DailyForecast";
 import HistoryPreview from "./HistoryPreview";
 import HourlyForecast from "./HourlyForecast";
+import { SearchRefProps } from "./LocationJumpButton";
 import Map from "./Map";
 import { UnitProps } from "./UnitButton";
 
 const FUTURE_FORECAST_DAYS = 6;
 
 function HomePage({
+  searchRef,
   units,
   weatherLocation,
   setWeatherLocation,
-}: UnitProps & WeatherLocationProps) {
+}: SearchRefProps & UnitProps & WeatherLocationProps) {
   const [combinedData, setCombinedData] = useState<CombinedData | null>(null);
 
   useEffect(() => {
@@ -44,6 +46,7 @@ function HomePage({
         <Grid container spacing={2}>
           <Grid item xs={12} sm={6} md={4}>
             <CurrentLocation
+              searchRef={searchRef}
               weatherLocation={weatherLocation}
               setWeatherLocation={setWeatherLocation}
             />

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -4,12 +4,11 @@ import { Container, Grid, Skeleton, Stack } from "@mui/material";
 
 import { WeatherLocationProps } from "../WeatherLocation";
 import { CombinedData, fetchCombinedData } from "../api/OpenMeteo";
-import CurrentLocation from "./CurrentLocation";
+import CurrentLocation, { LocationFocusProps } from "./CurrentLocation";
 import CurrentWeather from "./CurrentWeather";
 import DailyForecast from "./DailyForecast";
 import HistoryPreview from "./HistoryPreview";
 import HourlyForecast from "./HourlyForecast";
-import { SearchRefProps } from "./LocationJumpButton";
 import Map from "./Map";
 import { UnitProps } from "./UnitButton";
 
@@ -17,10 +16,12 @@ const FUTURE_FORECAST_DAYS = 6;
 
 function HomePage({
   searchRef,
+  locationExpanded,
+  setLocationExpanded,
   units,
   weatherLocation,
   setWeatherLocation,
-}: SearchRefProps & UnitProps & WeatherLocationProps) {
+}: LocationFocusProps & UnitProps & WeatherLocationProps) {
   const [combinedData, setCombinedData] = useState<CombinedData | null>(null);
 
   useEffect(() => {
@@ -47,6 +48,8 @@ function HomePage({
           <Grid item xs={12} sm={6} md={4}>
             <CurrentLocation
               searchRef={searchRef}
+              locationExpanded={locationExpanded}
+              setLocationExpanded={setLocationExpanded}
               weatherLocation={weatherLocation}
               setWeatherLocation={setWeatherLocation}
             />

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -42,7 +42,7 @@ function HomePage({
 
   return (
     <Container sx={{ padding: 0 }}>
-      <Stack gap={2} padding={{ xs: 1, sm: 1, md: 2 }}>
+      <Stack gap={2} padding={{ xs: 1, md: 2 }}>
         <Grid container spacing={2}>
           <Grid item xs={12} sm={6} md={4}>
             <CurrentLocation

--- a/src/components/LocationJumpButton.tsx
+++ b/src/components/LocationJumpButton.tsx
@@ -21,7 +21,7 @@ export function LocationJumpButton({
       variant="outlined"
       startIcon={isXMobileScreen ? undefined : <Place />}
       sx={{
-        minWidth: 0,
+        minWidth: 32,
         paddingInline: { xs: 1, sm: 2 },
         paddingBlock: 1,
         marginLeft: "auto",

--- a/src/components/LocationJumpButton.tsx
+++ b/src/components/LocationJumpButton.tsx
@@ -1,0 +1,36 @@
+import { MutableRefObject } from "react";
+
+import { Place } from "@mui/icons-material";
+import { Button } from "@mui/material";
+
+import {
+  WeatherLocationProps,
+  getShortLocationTitle,
+} from "../WeatherLocation";
+
+export interface SearchRefProps {
+  searchRef: MutableRefObject<HTMLInputElement | null>;
+}
+
+export function LocationJumpButton({
+  searchRef,
+  weatherLocation,
+}: SearchRefProps & WeatherLocationProps) {
+  return (
+    <Button
+      color="inherit"
+      variant="outlined"
+      startIcon={<Place />}
+      sx={{
+        paddingBlock: 1,
+        marginRight: 1,
+        display: { xs: "none", sm: "flex" },
+      }}
+      onClick={() => {
+        searchRef.current?.focus();
+      }}
+    >
+      {getShortLocationTitle(weatherLocation)}
+    </Button>
+  );
+}

--- a/src/components/LocationJumpButton.tsx
+++ b/src/components/LocationJumpButton.tsx
@@ -24,6 +24,7 @@ export function LocationJumpButton({
         minWidth: 0,
         paddingInline: { xs: 1, sm: 2 },
         paddingBlock: 1,
+        marginLeft: "auto",
         marginRight: 1,
       }}
       onClick={() => {

--- a/src/components/LocationJumpButton.tsx
+++ b/src/components/LocationJumpButton.tsx
@@ -7,6 +7,7 @@ import {
   WeatherLocationProps,
   getShortLocationTitle,
 } from "../WeatherLocation";
+import { useScreenSize } from "../utils/useScreenSize";
 
 export interface SearchRefProps {
   searchRef: MutableRefObject<HTMLInputElement | null>;
@@ -16,21 +17,24 @@ export function LocationJumpButton({
   searchRef,
   weatherLocation,
 }: SearchRefProps & WeatherLocationProps) {
+  const { isXMobileScreen } = useScreenSize();
+
   return (
     <Button
       color="inherit"
       variant="outlined"
-      startIcon={<Place />}
+      startIcon={isXMobileScreen ? undefined : <Place />}
       sx={{
+        minWidth: 0,
+        paddingInline: { xs: 1, sm: 2 },
         paddingBlock: 1,
         marginRight: 1,
-        display: { xs: "none", sm: "flex" },
       }}
       onClick={() => {
         searchRef.current?.focus();
       }}
     >
-      {getShortLocationTitle(weatherLocation)}
+      {isXMobileScreen ? <Place /> : getShortLocationTitle(weatherLocation)}
     </Button>
   );
 }

--- a/src/components/LocationJumpButton.tsx
+++ b/src/components/LocationJumpButton.tsx
@@ -1,5 +1,3 @@
-import { MutableRefObject } from "react";
-
 import { Place } from "@mui/icons-material";
 import { Button } from "@mui/material";
 
@@ -8,15 +6,13 @@ import {
   getShortLocationTitle,
 } from "../WeatherLocation";
 import { useScreenSize } from "../utils/useScreenSize";
-
-export interface SearchRefProps {
-  searchRef: MutableRefObject<HTMLInputElement | null>;
-}
+import { LocationFocusProps } from "./CurrentLocation";
 
 export function LocationJumpButton({
   searchRef,
+  setLocationExpanded,
   weatherLocation,
-}: SearchRefProps & WeatherLocationProps) {
+}: LocationFocusProps & WeatherLocationProps) {
   const { isXMobileScreen } = useScreenSize();
 
   return (
@@ -31,7 +27,12 @@ export function LocationJumpButton({
         marginRight: 1,
       }}
       onClick={() => {
-        searchRef.current?.focus();
+        setLocationExpanded(true);
+        // Wait until the current location component has finished expanding
+        // before jumping to the search input.
+        setTimeout(() => {
+          searchRef.current?.focus();
+        }, 150);
       }}
     >
       {isXMobileScreen ? <Place /> : getShortLocationTitle(weatherLocation)}

--- a/src/components/MapsPage/MapsPage.tsx
+++ b/src/components/MapsPage/MapsPage.tsx
@@ -23,8 +23,7 @@ import {
   getWeatherByCoordinates,
 } from "../../api/WeatherApi";
 import { useScreenSize } from "../../utils/useScreenSize";
-import CurrentLocation from "../CurrentLocation";
-import { SearchRefProps } from "../LocationJumpButton";
+import CurrentLocation, { LocationFocusProps } from "../CurrentLocation";
 import { UnitProps } from "../UnitButton";
 import tileLayer from "./TileLayer";
 
@@ -32,11 +31,13 @@ const cityNames = ["Chicago", "Portland", "New York", "Oregon", "Boston"];
 
 function MapsPage({
   searchRef,
+  locationExpanded,
+  setLocationExpanded,
   units,
   setUnits,
   weatherLocation,
   setWeatherLocation,
-}: SearchRefProps & UnitProps & WeatherLocationProps) {
+}: LocationFocusProps & UnitProps & WeatherLocationProps) {
   const [locationWeatherData, setLocationWeatherData] =
     useState<WeatherResponse>();
 
@@ -83,7 +84,8 @@ function MapsPage({
           <Grid item xs={12} sm={6} md={4}>
             <CurrentLocation
               collapsible
-              startOpened={false}
+              locationExpanded={locationExpanded}
+              setLocationExpanded={setLocationExpanded}
               searchRef={searchRef}
               weatherLocation={weatherLocation}
               setWeatherLocation={setWeatherLocation}

--- a/src/components/MapsPage/MapsPage.tsx
+++ b/src/components/MapsPage/MapsPage.tsx
@@ -6,6 +6,7 @@ import { MapContainer, TileLayer, useMap } from "react-leaflet";
 import {
   Box,
   Container,
+  Grid,
   ListItemText,
   Stack,
   Typography,
@@ -22,17 +23,20 @@ import {
   getWeatherByCoordinates,
 } from "../../api/WeatherApi";
 import { useScreenSize } from "../../utils/useScreenSize";
+import CurrentLocation from "../CurrentLocation";
+import { SearchRefProps } from "../LocationJumpButton";
 import { UnitProps } from "../UnitButton";
 import tileLayer from "./TileLayer";
 
 const cityNames = ["Chicago", "Portland", "New York", "Oregon", "Boston"];
 
 function MapsPage({
+  searchRef,
   units,
   setUnits,
   weatherLocation,
   setWeatherLocation,
-}: UnitProps & WeatherLocationProps) {
+}: SearchRefProps & UnitProps & WeatherLocationProps) {
   const [locationWeatherData, setLocationWeatherData] =
     useState<WeatherResponse>();
 
@@ -65,7 +69,28 @@ function MapsPage({
   return (
     <Container sx={{ padding: 0 }}>
       <Stack gap={2} padding={{ xs: 1, md: 2 }}>
-        {locationWeatherData && <LocationBox data={locationWeatherData} />}
+        <Grid container spacing={2} justifyItems="center">
+          <Grid item xs={12} sm={6} md={8} alignSelf="center">
+            <Typography
+              height="100%"
+              variant="h2"
+              component="h1"
+              textAlign="center"
+            >
+              Interactive Map
+            </Typography>
+          </Grid>
+          <Grid item xs={12} sm={6} md={4}>
+            <CurrentLocation
+              collapsible
+              startOpened={false}
+              searchRef={searchRef}
+              weatherLocation={weatherLocation}
+              setWeatherLocation={setWeatherLocation}
+            />
+          </Grid>
+        </Grid>
+
         <MapView
           center={
             new LatLng(weatherLocation.latitude, weatherLocation.longitude)
@@ -219,33 +244,6 @@ const LocationCondition = ({ data, units }: LocationConditionProps) => {
       <WeatherItem primary={`${current?.humidity}`} secondary="Humidity" />
       <WeatherItem primary={`${current?.wind_kph} KM/H`} secondary="Wind" />
     </Stack>
-  );
-};
-
-// Component to display location details for the selected location
-const LocationBox = ({ data }: { data: WeatherResponse }) => {
-  const { location } = data;
-
-  return (
-    <Box
-      sx={{
-        backgroundColor: "white",
-        borderRadius: 2,
-        width: "fit-content",
-        px: 3,
-        py: 2,
-      }}
-    >
-      <Typography variant="h6" gutterBottom>
-        {location?.name}
-      </Typography>
-      <Typography>{location?.localtime}</Typography>
-      <Typography>{location?.country}</Typography>
-      <Typography>{location?.region}</Typography>
-      <Typography>
-        {location?.lat} , {location?.lon}
-      </Typography>
-    </Box>
   );
 };
 

--- a/src/components/MapsPage/MapsPage.tsx
+++ b/src/components/MapsPage/MapsPage.tsx
@@ -3,7 +3,14 @@ import "leaflet/dist/leaflet.css";
 import React, { useEffect, useState } from "react";
 import { MapContainer, TileLayer, useMap } from "react-leaflet";
 
-import { Box, ListItemText, Stack, Typography, debounce } from "@mui/material";
+import {
+  Box,
+  Container,
+  ListItemText,
+  Stack,
+  Typography,
+  debounce,
+} from "@mui/material";
 
 import {
   WeatherLocationProps,
@@ -56,30 +63,29 @@ function MapsPage({
   );
 
   return (
-    <Stack
-      sx={{
-        padding: 6,
-      }}
-      direction="column"
-    >
-      {locationWeatherData && <LocationBox data={locationWeatherData} />}
-      <MapView
-        center={new LatLng(weatherLocation.latitude, weatherLocation.longitude)}
-        onMapClicked={(latLng: LatLng) => {
-          void fetchWeatherLocation(latLng);
-        }}
-      />
-
-      {locationWeatherData && (
-        <LocationCondition
-          data={locationWeatherData}
-          units={units}
-          setUnits={setUnits}
+    <Container sx={{ padding: 0 }}>
+      <Stack gap={2} padding={{ xs: 1, md: 2 }}>
+        {locationWeatherData && <LocationBox data={locationWeatherData} />}
+        <MapView
+          center={
+            new LatLng(weatherLocation.latitude, weatherLocation.longitude)
+          }
+          onMapClicked={(latLng: LatLng) => {
+            void fetchWeatherLocation(latLng);
+          }}
         />
-      )}
 
-      <MajorCitiesConditions units={units} setUnits={setUnits} />
-    </Stack>
+        {locationWeatherData && (
+          <LocationCondition
+            data={locationWeatherData}
+            units={units}
+            setUnits={setUnits}
+          />
+        )}
+
+        <MajorCitiesConditions units={units} setUnits={setUnits} />
+      </Stack>
+    </Container>
   );
 }
 
@@ -98,7 +104,6 @@ const MapView = ({ center, onMapClicked }: MapViewProps) => {
         border: "1px solid #e0e0e0",
         borderRadius: "8px",
         overflow: "hidden",
-        marginBottom: "24px",
       }}
     >
       <MapContainer
@@ -155,7 +160,6 @@ const MajorCityBox = ({ data, units }: MajorCityBoxProps) => {
         width: "100%",
         px: 3,
         py: 2,
-        mb: 3,
       }}
     >
       <Typography variant="h6" gutterBottom>
@@ -206,11 +210,7 @@ const LocationCondition = ({ data, units }: LocationConditionProps) => {
   const temp = units.temperature === "C" ? current?.temp_c : current?.temp_f;
 
   return (
-    <Stack
-      direction={isXMobileScreen ? "column" : "row"}
-      spacing={2}
-      sx={{ mb: 3 }}
-    >
+    <Stack direction={isXMobileScreen ? "column" : "row"} spacing={2}>
       <WeatherItem
         primary={`${temp ?? 0}°${units.temperature}`}
         secondary="Temperature"
@@ -234,7 +234,6 @@ const LocationBox = ({ data }: { data: WeatherResponse }) => {
         width: "fit-content",
         px: 3,
         py: 2,
-        mb: 3,
       }}
     >
       <Typography variant="h6" gutterBottom>

--- a/src/components/MapsPage/MapsPage.tsx
+++ b/src/components/MapsPage/MapsPage.tsx
@@ -145,18 +145,19 @@ const MapView = ({ center, onMapClicked }: MapViewProps) => {
         scrollWheelZoom={false}
       >
         <TileLayer {...tileLayer} />
-        <InteractiveMap onMapClicked={onMapClicked} />
+        <InteractiveMap center={center} onMapClicked={onMapClicked} />
       </MapContainer>
     </Box>
   );
 };
 
-const InteractiveMap = ({
-  onMapClicked,
-}: {
-  onMapClicked: (latlng: LatLng) => void;
-}) => {
+const InteractiveMap = ({ center, onMapClicked }: MapViewProps) => {
   const map = useMap();
+
+  useEffect(() => {
+    // Move map view when the current location is changed.
+    map.setView(center);
+  }, [map, center]);
 
   useEffect(() => {
     // Listen for map clicks and invoke onMapClicked callback


### PR DESCRIPTION
Previously, the only way to change the location was through the single location box on the home page.
This made it uncomfortable to quickly check different cities. It also meant that there was no indication of the current city on the historical data page.

This PR fixes that by adding a version of the current location component on the map and history pages.

- An option has been added to the component to allow it to collapse & expand to save vertical space.
- To fill the remaining horizontal space, the page title is displayed. This was eventually going to be necessary anyways to fulfill accessibility requirements for an `<h1>`.

On the map page specifically, the current location component replaced the older `<LocationBox>` since it displays almost the same data (except for time, which can be added later). Using the current location component here also makes the city names consistent, since WeatherAPI sometimes has different names for cities.

As an additional feature, the navbar now has a button with a short location name. Clicking the button automatically expands the current location component and moves focus to the search input. This is useful for mobile devices since the pages get longer and would otherwise require scrolling to the top.

<details>
<summary><h1> Previews (5 screenshots, click to expand) </h1></summary>

## Map Page (Collapsed)

![image](https://github.com/mnxn/weather/assets/25037249/8aeb1d82-bff8-4d07-9dd8-d3bbc32013ec)

## Map Page (Expanded)

![image](https://github.com/mnxn/weather/assets/25037249/8a8df73e-b9a0-45da-bad5-301698a150ab)

## History Page (`md` layout)

![image](https://github.com/mnxn/weather/assets/25037249/a2995b63-9066-43a6-8f04-7943374462cc)

## History Page (`sm` layout)

![image](https://github.com/mnxn/weather/assets/25037249/1c7d3da9-200b-46f8-ac70-e3c41a253a34)

## History Page (`xs` layout)

![image](https://github.com/mnxn/weather/assets/25037249/20880953-02f6-488c-afd6-099c8d3b8d89)

</details>