### PR TITLE
Add icon to current weather component

### DIFF
--- a/src/components/CurrentWeather.tsx
+++ b/src/components/CurrentWeather.tsx
@@ -1,28 +1,63 @@
 import React from "react";
-import { Card, CardContent, CardHeader, Chip, Stack } from "@mui/material";
 
-interface CurrentWeatherProps {
+import { Box, Card, CardContent, CardHeader, Chip, Stack } from "@mui/material";
+
+import HighLowTemps from "./HighLowTemps";
+import { UnitProps } from "./UnitButton";
+import { WmoCode, weatherDescription, weatherIconClass } from "./WmoCode";
+
+interface CurrentWeatherProps extends UnitProps {
   time: string;
+  weather: WmoCode;
   temperature: number;
   humidity: number;
   windSpeed: number;
+  cloudCover: number;
   maxTemperature: number;
   minTemperature: number;
 }
 
-const CurrentWeather: React.FC<CurrentWeatherProps> = ({ time, temperature, humidity, windSpeed, maxTemperature, minTemperature}) => {
+const CurrentWeather: React.FC<CurrentWeatherProps> = ({
+  time,
+  weather,
+  temperature,
+  humidity,
+  windSpeed,
+  cloudCover,
+  maxTemperature,
+  minTemperature,
+  units,
+}) => {
+  const timeString = new Date(time).toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "numeric",
+  });
+
   return (
-    <Card>
+    <Card sx={{ height: "100%" }}>
       <CardHeader
-        title={`Current Temperature: ${temperature}°C`}
-        subheader={`As of ${time}`}
+        action={
+          <Box
+            className={`wi ${weatherIconClass(weather)}`}
+            fontSize={50}
+            paddingTop={1.5}
+            paddingInline={1.5}
+          />
+        }
+        title={`${temperature} °${units.temperature}`}
+        subheader={`As of ${timeString}`}
       />
-      <CardContent>
+      <CardContent sx={{ paddingTop: 0 }}>
         <Stack gap={2}>
-          <Chip label={`Max Temperature: ${maxTemperature}`} />
-          <Chip label={`Min Temperature: ${minTemperature}`} />
+          <Stack direction="row" justifyContent="space-between">
+            <HighLowTemps high={maxTemperature} low={minTemperature} />
+            {weatherDescription(weather)}
+          </Stack>
           <Chip label={`Humidity: ${humidity}%`} />
           <Chip label={`Wind Speed: ${windSpeed} m/s`} />
+          <Chip label={`Cloud Cover: ${cloudCover}%`} />
         </Stack>
       </CardContent>
     </Card>

--- a/src/components/DailyForecast.tsx
+++ b/src/components/DailyForecast.tsx
@@ -1,6 +1,7 @@
-import { Box, Divider, Paper, Stack, Tooltip } from "@mui/material";
-import { blue, red } from "@mui/material/colors";
+import { Box, Paper, Stack } from "@mui/material";
+import { blue } from "@mui/material/colors";
 
+import HighLowTemps from "./HighLowTemps";
 import { WmoCode, weatherDescription, weatherIconClass } from "./WmoCode";
 
 export interface DailyForecastProps {
@@ -34,19 +35,9 @@ function DailyForecast(props: DailyForecastProps) {
           marginBlock={1}
         />
         <Box>{weatherDescription(props.weather)}</Box>
-        <Stack direction="row" gap={1} marginBlock={1} alignItems="center">
-          <Tooltip title="High Temperature">
-            <Box fontWeight="bold" color={red[500]}>
-              {props.high}&deg;
-            </Box>
-          </Tooltip>
-          <Divider orientation="vertical" flexItem />
-          <Tooltip title="Low Temperature">
-            <Box fontWeight="bold" color={blue[500]}>
-              {props.low}&deg;
-            </Box>
-          </Tooltip>
-        </Stack>
+        <Box marginBlock={1}>
+          <HighLowTemps high={props.high} low={props.low} />
+        </Box>
       </Stack>
     </Paper>
   );

--- a/src/components/HighLowTemps.tsx
+++ b/src/components/HighLowTemps.tsx
@@ -1,0 +1,26 @@
+import { Box, Divider, Stack, Tooltip } from "@mui/material";
+import { blue, red } from "@mui/material/colors";
+
+export default function HighLowTemps({
+  high,
+  low,
+}: {
+  high: number;
+  low: number;
+}) {
+  return (
+    <Stack direction="row" gap={1.5} alignItems="center">
+      <Tooltip title="High Temperature">
+        <Box fontWeight="bold" color={red[500]}>
+          {high}&deg;
+        </Box>
+      </Tooltip>
+      <Divider orientation="vertical" flexItem />
+      <Tooltip title="Low Temperature">
+        <Box fontWeight="bold" color={blue[500]}>
+          {low}&deg;
+        </Box>
+      </Tooltip>
+    </Stack>
+  );
+}

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -9,8 +9,8 @@ import CurrentWeather from "./CurrentWeather";
 import DailyForecast from "./DailyForecast";
 import HistoryPreview from "./HistoryPreview";
 import HourlyForecast from "./HourlyForecast";
+import MapPreview from "./MapPreview";
 import { UnitProps } from "./UnitButton";
-import MapPreview from "./MapPreview"; 
 
 const FUTURE_FORECAST_DAYS = 6;
 
@@ -19,6 +19,7 @@ function HomePage({
   locationExpanded,
   setLocationExpanded,
   units,
+  setUnits,
   weatherLocation,
   setWeatherLocation,
 }: LocationFocusProps & UnitProps & WeatherLocationProps) {
@@ -54,21 +55,31 @@ function HomePage({
             />
           </Grid>
           <Grid item xs={12} sm={6} md={4}>
-            <CurrentWeather
-              time={combinedData?.current.time ?? ""}
-              temperature={combinedData?.current.temperature_2m ?? 0}
-              humidity={combinedData?.current.relative_humidity_2m ?? 0}
-              windSpeed={combinedData?.current.wind_speed_10m ?? 0}
-              maxTemperature={combinedData?.daily.temperature_2m_max[0] ?? 0}
-              minTemperature={combinedData?.daily.temperature_2m_min[0] ?? 0}
-            />
+            {combinedData === null ? (
+              <Skeleton variant="rectangular" height="100%" />
+            ) : (
+              <CurrentWeather
+                time={combinedData.current.time}
+                weather={combinedData.current.weather_code}
+                temperature={combinedData.current.temperature_2m}
+                humidity={combinedData.current.relative_humidity_2m}
+                windSpeed={combinedData.current.wind_speed_10m}
+                cloudCover={combinedData.current.cloud_cover}
+                maxTemperature={combinedData.daily.temperature_2m_max[0]}
+                minTemperature={combinedData.daily.temperature_2m_min[0]}
+                units={units}
+                setUnits={setUnits}
+              />
+            )}
           </Grid>
 
           <Grid item xs={12} md={4}>
-            <MapPreview center={{
+            <MapPreview
+              center={{
                 lat: weatherLocation.latitude,
                 lng: weatherLocation.longitude,
-              }} />
+              }}
+            />
           </Grid>
         </Grid>
 


### PR DESCRIPTION
This PR adds an icon and weather description to the current weather component since the data for the current day is not available from the daily forecasts. I had to collapse the max/min temperatures into a single line for there to be enough space for the weather description. Luckily, this also added enough space for another data point, so the cloud cover is visible now.

![image](https://github.com/mnxn/weather/assets/25037249/1b0541d2-0062-4f04-9a33-a2f339d3ec6b)
