### PR TITLE
Update map preview on location change

### DIFF
--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -75,10 +75,8 @@ function HomePage({
 
           <Grid item xs={12} md={4}>
             <MapPreview
-              center={{
-                lat: weatherLocation.latitude,
-                lng: weatherLocation.longitude,
-              }}
+              weatherLocation={weatherLocation}
+              setWeatherLocation={setWeatherLocation}
             />
           </Grid>
         </Grid>

--- a/src/components/MapPreview/index.tsx
+++ b/src/components/MapPreview/index.tsx
@@ -1,26 +1,50 @@
-
-import { Box, IconButton } from "@mui/material";
-import { MapContainer, TileLayer } from "react-leaflet";
+import { LatLng } from "leaflet";
 import "leaflet/dist/leaflet.css";
-import tileLayer from "./TileLayer";
+import React from "react";
+import { MapContainer, TileLayer } from "react-leaflet";
 import { Link } from "react-router-dom";
-import OpenInFullIcon from '@mui/icons-material/OpenInFull';
 
-interface MapPreviewProps {
-  center: { lat: number; lng: number };
-}
+import OpenInFullIcon from "@mui/icons-material/OpenInFull";
+import { Box, IconButton, debounce } from "@mui/material";
 
-const MapPreview = ({ center}: MapPreviewProps) => {
+import {
+  WeatherLocationProps,
+  reverseWeatherLocation,
+} from "../../WeatherLocation";
+import { InteractiveMap } from "../MapsPage/MapsPage";
+import tileLayer from "./TileLayer";
+
+const MapPreview = ({
+  weatherLocation,
+  setWeatherLocation,
+}: WeatherLocationProps) => {
+  const center = new LatLng(
+    weatherLocation.latitude,
+    weatherLocation.longitude,
+  );
+
+  const fetchWeatherLocation = React.useMemo(
+    () =>
+      debounce(async (latLng: LatLng) => {
+        const reversedLocation = await reverseWeatherLocation(
+          latLng.lat,
+          latLng.lng,
+        );
+        setWeatherLocation(reversedLocation);
+      }, 500),
+    [setWeatherLocation],
+  );
+
   return (
     <Box
       sx={{
         position: "relative",
         minHeight: "200px",
-        height: "100%", 
+        height: "100%",
         width: "100%",
         borderRadius: "8px",
         overflow: "hidden",
-        marginBottom: "16px", 
+        marginBottom: "16px",
       }}
     >
       <MapContainer
@@ -29,11 +53,17 @@ const MapPreview = ({ center}: MapPreviewProps) => {
           width: "100%",
           overflow: "hidden",
         }}
-        center={[center.lat, center.lng]}
-        zoom={10} 
+        center={center}
+        zoom={10}
         scrollWheelZoom={false}
       >
-      <TileLayer {...tileLayer} />
+        <TileLayer {...tileLayer} />
+        <InteractiveMap
+          center={center}
+          onMapClicked={(latLng: LatLng) => {
+            void fetchWeatherLocation(latLng);
+          }}
+        />
       </MapContainer>
 
       <Box
@@ -45,15 +75,15 @@ const MapPreview = ({ center}: MapPreviewProps) => {
         }}
       >
         <Link to="/Maps" style={{ textDecoration: "none" }}>
-        <IconButton 
+          <IconButton
             aria-label="Go to MapsPage"
-            sx={{ bgcolor: "white", color: "black" }}>
+            sx={{ bgcolor: "white", color: "black" }}
+          >
             <OpenInFullIcon />
           </IconButton>
         </Link>
       </Box>
     </Box>
-
   );
 };
 

--- a/src/components/MapsPage/MapsPage.tsx
+++ b/src/components/MapsPage/MapsPage.tsx
@@ -151,7 +151,7 @@ const MapView = ({ center, onMapClicked }: MapViewProps) => {
   );
 };
 
-const InteractiveMap = ({ center, onMapClicked }: MapViewProps) => {
+export const InteractiveMap = ({ center, onMapClicked }: MapViewProps) => {
   const map = useMap();
 
   useEffect(() => {


### PR DESCRIPTION
This is a small change to the map preview so it updates the map view when the current weather location changes.
Before this PR, the map on the home page would show the old position after the user changes locations.

This functionality was already added to the full map page in a previous PR: https://github.com/mnxn/weather/pull/22#issuecomment-1831618917 