### PR TITLE
Use HTTPS for WeatherApi

### DIFF
--- a/src/api/WeatherApi.tsx
+++ b/src/api/WeatherApi.tsx
@@ -42,7 +42,7 @@ export interface WeatherForecastResponse {
 }
 
 const API_KEY = import.meta.env.VITE_WEATHER_API_KEY;
-const BASE_URL = "http://api.weatherapi.com/v1";
+const BASE_URL = "https://api.weatherapi.com/v1";
 
 // Function to fetch current weather by city name
 export async function getWeatherByCity(city: string): Promise<WeatherResponse> {


### PR DESCRIPTION
Currently, if you visit the map page through the hosted website, many of the components don't load. Looking into the console reveals these errors:

> Mixed Content: The page at 'https://emweather.vercel.app/maps' was loaded over HTTPS, but requested an insecure resource 'http://api.weatherapi.com/v1/current.json?...' This request has been blocked; the content must be served over HTTPS.

It's a simple fix by changing the BASE_URL value to use HTTPS.

I didn't catch this problem until now because my Firefox browser has a setting enabled to automatically upgrade HTTP requests to HTTPS. The local servers with `npm run dev` also didn't raise this issue because they don't use HTTPS.

