### PR TITLE
Fix Linking Bugs

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -28,7 +28,7 @@ export default function Footer() {
 
         <Link href="https://www.weatherapi.com/" title="Free Weather API">
           <img
-            src="//cdn.weatherapi.com/v4/images/weatherapi_logo.png"
+            src="https://cdn.weatherapi.com/v4/images/weatherapi_logo.png"
             alt="Weather data by WeatherAPI.com"
             width={107}
             height={50}

--- a/src/components/MapPreview/index.tsx
+++ b/src/components/MapPreview/index.tsx
@@ -68,8 +68,8 @@ export default function MapPreview({
       <Box position="absolute" zIndex={999} bottom="8px" left="8px">
         <Paper sx={{ borderRadius: 5 }}>
           <IconButton
-            LinkComponent={Link}
-            href="/Maps"
+            component={Link}
+            to="/maps"
             aria-label="Go to Maps Page"
             color="inherit"
           >

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -29,11 +29,18 @@ if (!import.meta.env.PROD) {
 }
 
 // Leaflet Marker icons need to be set explicitly or they will 404 in production.
+// The integer values are from https://stackoverflow.com/a/51232969
+// They are necessary for the marker to be placed properly on the map.
 L.Marker.prototype.setIcon(
   L.icon({
     iconRetinaUrl,
     iconUrl,
     shadowUrl,
+    iconSize: [25, 41],
+    iconAnchor: [12, 41],
+    popupAnchor: [1, -34],
+    tooltipAnchor: [16, -28],
+    shadowSize: [41, 41],
   }),
 );
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,8 @@
 import { ThemeProvider } from "@emotion/react";
+import L from "leaflet";
+import iconRetinaUrl from "leaflet/dist/images/marker-icon-2x.png";
+import iconUrl from "leaflet/dist/images/marker-icon.png";
+import shadowUrl from "leaflet/dist/images/marker-shadow.png";
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
@@ -23,6 +27,15 @@ async function loadAxeCore() {
 if (!import.meta.env.PROD) {
   void loadAxeCore();
 }
+
+// Leaflet Marker icons need to be set explicitly or they will 404 in production.
+L.Marker.prototype.setIcon(
+  L.icon({
+    iconRetinaUrl,
+    iconUrl,
+    shadowUrl,
+  }),
+);
 
 const theme = createTheme({
   palette: {


### PR DESCRIPTION
This PR fixes a few remaining bugs I found in the website. Coincidentally, they are related to links.

1. The map expand button wasn't working because the `Link` component was reference incorrectly. Changing the attributes from `LinkComponent`/`href` to `component`/`to` fixed the issue.

2. The Leaflet marker icon was not showing up and caused 404s in the console. I read other people's experience in a Stack Overflow answer and wrote a similar solution by importing the icons PNGs and setting the default icon explicitly: https://stackoverflow.com/a/51232969

3. The least impactful issue, but the URL that WeatherApi provided started with `//`, which was being interpreted as an HTTP url. Expanding it to `http://` prevents some console warnings.